### PR TITLE
Redirect to questionnaire details page after creation

### DIFF
--- a/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
+++ b/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
@@ -2,6 +2,7 @@
 @using Namezr.Client.Types
 @using vNext.BlazorComponents.FluentValidation
 @using Namezr.Client.Studio.Eligibility.Edit
+@using System.Text.Json
 
 @rendermode InteractiveWebAssembly
 
@@ -225,7 +226,15 @@
 
             HxMessenger.AddInformation("Questionnaire saved");
 
-            // TODO: redirect to studio questionnaire details page
+            // Redirect to details page for new questionnaires
+            if (!QuestionnaireId.HasValue)
+            {
+                string responseContent = await response.Content.ReadAsStringAsync();
+                Guid createdId = JsonSerializer.Deserialize<Guid>(responseContent);
+                
+                string detailsUrl = $"/studio/{CreatorId.NoHyphens()}/questionnaires/{createdId.NoHyphens()}";
+                NavigationManager.NavigateTo(detailsUrl);
+            }
         }
         finally
         {


### PR DESCRIPTION
Implement redirect logic in QuestionnaireEditor.razor to navigate users to the questionnaire details page after successfully creating a new questionnaire.

- Added System.Text.Json using statement for response parsing
- Parse API response to get created questionnaire ID
- Navigate to details page using /studio/{creatorId}/questionnaires/{id} format
- Only redirect for new questionnaires, not edits

Fixes #116

🤖 Generated with [Claude Code](https://claude.ai/code)