### PR TITLE
feat: replace 'require approval' with 'manual approval' in dropdown labels

### DIFF
--- a/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
+++ b/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
@@ -262,8 +262,8 @@
     private static readonly IReadOnlyList<(QuestionnaireApprovalMode mode, string label)> ApprovalModeOptions =
     [
         (QuestionnaireApprovalMode.GrantAutomatically, "Granted automatically"),
-        (QuestionnaireApprovalMode.RequireApprovalRemoveWhenEdited, "Require approval (remove when edited)"),
-        (QuestionnaireApprovalMode.RequireApprovalProhibitEditingApproved, "Require approval (prohibit editing when approved)"),
+        (QuestionnaireApprovalMode.RequireApprovalRemoveWhenEdited, "Manual approval (remove when edited)"),
+        (QuestionnaireApprovalMode.RequireApprovalProhibitEditingApproved, "Manual approval (prohibit editing when approved)"),
     ];
 
     private static readonly IReadOnlyList<(QuestionnaireSubmissionOpenMode mode, string label)> SubmissionOpenModeOptions =


### PR DESCRIPTION
Update questionnaire approval mode dropdown options to use 'Manual approval' instead of 'Require approval' for better clarity.

Fixes #130

Generated with [Claude Code](https://claude.ai/code)