### PR TITLE
Add hint to questionnaire editor fields section

### DIFF
--- a/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
+++ b/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
@@ -94,7 +94,9 @@
             <div class="row">
                 <div class="col-11">
                     <h3>Fields</h3>
-                    <div class="text-muted small">These fields will be filled in by submitters</div>
+                    <div class="text-muted small">
+                        Configure fields/inputs that will be filled in by the submitters
+                    </div>
                 </div>
                 <div class="col-1 text-right">
                     <HxButton

--- a/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
+++ b/Namezr.Client/Studio/Questionnaires/Edit/QuestionnaireEditor.razor
@@ -94,6 +94,7 @@
             <div class="row">
                 <div class="col-11">
                     <h3>Fields</h3>
+                    <div class="text-muted small">These fields will be filled in by submitters</div>
                 </div>
                 <div class="col-1 text-right">
                     <HxButton


### PR DESCRIPTION
Add explanatory text "These fields will be filled in by submitters" to the Fields section header in the questionnaire editor to help users understand the purpose of the fields they are creating.

Resolves #132

Generated with [Claude Code](https://claude.ai/code)