### PR TITLE
Add header for submitter comment input

### DIFF
--- a/Namezr/Features/Questionnaires/Pages/QuestionnaireHome.razor
+++ b/Namezr/Features/Questionnaires/Pages/QuestionnaireHome.razor
@@ -186,6 +186,12 @@
 @if (_context.SubmissionForUpdate is not null)
 {
     <HxCard>
+        <HeaderTemplate>
+            <div>
+                <h5 class="mb-1">Comments</h5>
+                <small class="text-muted">Use this section to communicate with the staff about your submission</small>
+            </div>
+        </HeaderTemplate>
         <BodyTemplate>
             <EditForm Model="NewComment" FormName="new-comment" OnValidSubmit="OnValidSubmitNewComment">
                 <FluentValidationValidator/>


### PR DESCRIPTION
Added a 'Comments' header with description explaining that submitters can use this section to communicate with staff about their submission.

Closes #134

Generated with [Claude Code](https://claude.ai/code)